### PR TITLE
feat(export): make algorithm/pipeline info part of export + add in no…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,21 @@ poetry run causy execute tests/fixtures/toy_data_larger.json --pipeline pc.json
 ### Usage via Code
 
 Use a default algorithm
+
 ```python
 from causy.algorithms import PC
-from causy.utils import show_edges
+from causy.utils import retrieve_edges
 
 model = PC()
 model.create_graph_from_data(
     [
-        {"a": 1, "b": 0.3}, 
+        {"a": 1, "b": 0.3},
         {"a": 0.5, "b": 0.2}
     ]
 )
 model.create_all_possible_edges()
 model.execute_pipeline_steps()
-edges = show_edges(model.graph)
+edges = retrieve_edges(model.graph)
 
 for edge in edges:
     print(

--- a/causy/cli.py
+++ b/causy/cli.py
@@ -92,10 +92,17 @@ def execute(
 
     typer.echo("🕵🏻‍♀  Executing pipeline steps...")
     model.execute_pipeline_steps()
-    edges = retrieve_edges(model.graph)
-    for edge in edges:
+    edges = []
+    for edge in retrieve_edges(model.graph):
         print(
             f"{edge[0].name} -> {edge[1].name}: {model.graph.edges[edge[0]][edge[1]]}"
+        )
+        edges.append(
+            {
+                "from": edge[0].to_dict(),
+                "to": edge[1].to_dict(),
+                "value": model.graph.edges[edge[0]][edge[1]],
+            }
         )
 
     if output_file:

--- a/causy/cli.py
+++ b/causy/cli.py
@@ -59,7 +59,7 @@ def execute(
     data_file: str,
     pipeline: str = None,
     algorithm: str = None,
-    graph_actions_save_file: str = None,
+    output_file: str = None,
     render_save_file: str = None,
     log_level: str = "ERROR",
 ):
@@ -98,9 +98,9 @@ def execute(
             f"{edge[0].name} -> {edge[1].name}: {model.graph.edges[edge[0]][edge[1]]}"
         )
 
-    if graph_actions_save_file:
-        typer.echo(f"💾 Saving graph actions to {graph_actions_save_file}")
-        with open(graph_actions_save_file, "w") as file:
+    if output_file:
+        typer.echo(f"💾 Saving graph actions to {output_file}")
+        with open(output_file, "w") as file:
             export = {
                 "name": algorithm,
                 "created_at": datetime.now().isoformat(),

--- a/causy/generators.py
+++ b/causy/generators.py
@@ -78,7 +78,7 @@ class PairsWithNeighboursGenerator(GeneratorInterface):
 
                     checked_combinations.add((node, neighbour))
                     if i == 2:
-                        yield (node.name, neighbour.name)
+                        yield (node.id, neighbour.id)
                         continue
 
                     other_neighbours = set(graph.edges[node])
@@ -87,4 +87,4 @@ class PairsWithNeighboursGenerator(GeneratorInterface):
                         continue
 
                     for k in itertools.combinations(other_neighbours, i):
-                        yield [node.name, neighbour.name] + [ks.name for ks in k]
+                        yield [node.id, neighbour.id] + [ks.id for ks in k]

--- a/causy/graph.py
+++ b/causy/graph.py
@@ -1,10 +1,8 @@
-import importlib
-import itertools
-import json
 from abc import ABC
 from dataclasses import dataclass
 from typing import List, Optional, Dict, Set
 import multiprocessing as mp
+from uuid import uuid4
 
 from causy.interfaces import (
     IndependenceTestInterface,
@@ -33,10 +31,11 @@ logger = logging.getLogger(__name__)
 @dataclass
 class Node(NodeInterface):
     name: str
+    id: str
     values: List[float]
 
     def __hash__(self):
-        return hash(self.name)
+        return hash(self.id)
 
 
 class UndirectedGraphError(Exception):
@@ -62,9 +61,9 @@ class UndirectedGraph(BaseGraphInterface):
         :param v: v node
         :return:
         """
-        if u.name not in self.nodes:
+        if u.id not in self.nodes:
             raise UndirectedGraphError(f"Node {u} does not exist")
-        if v.name not in self.nodes:
+        if v.id not in self.nodes:
             raise UndirectedGraphError(f"Node {v} does not exist")
         if u not in self.edges:
             self.edges[u] = {}
@@ -104,9 +103,9 @@ class UndirectedGraph(BaseGraphInterface):
         :param v: v node
         :return:
         """
-        if u.name not in self.nodes:
+        if u.id not in self.nodes:
             raise UndirectedGraphError(f"Node {u} does not exist")
-        if v.name not in self.nodes:
+        if v.id not in self.nodes:
             raise UndirectedGraphError(f"Node {v} does not exist")
         if u not in self.edges:
             raise UndirectedGraphError(f"Node {u} does not have any nodes")
@@ -128,9 +127,9 @@ class UndirectedGraph(BaseGraphInterface):
         :param v: v node
         :return:
         """
-        if u.name not in self.nodes:
+        if u.id not in self.nodes:
             raise UndirectedGraphError(f"Node {u} does not exist")
-        if v.name not in self.nodes:
+        if v.id not in self.nodes:
             raise UndirectedGraphError(f"Node {v} does not exist")
         if u not in self.edges:
             raise UndirectedGraphError(f"Node {u} does not have any nodes")
@@ -148,9 +147,9 @@ class UndirectedGraph(BaseGraphInterface):
         :param v: v node
         :return:
         """
-        if u.name not in self.nodes:
+        if u.id not in self.nodes:
             raise UndirectedGraphError(f"Node {u} does not exist")
-        if v.name not in self.nodes:
+        if v.id not in self.nodes:
             raise UndirectedGraphError(f"Node {v} does not exist")
         if u not in self.edges:
             raise UndirectedGraphError(f"Node {u} does not have any edges")
@@ -167,9 +166,9 @@ class UndirectedGraph(BaseGraphInterface):
         :param v: node v
         :return: True if any edge exists, False otherwise
         """
-        if u.name not in self.nodes:
+        if u.id not in self.nodes:
             return False
-        if v.name not in self.nodes:
+        if v.id not in self.nodes:
             return False
         if u in self.edges and v in self.edges[u]:
             return True
@@ -184,9 +183,9 @@ class UndirectedGraph(BaseGraphInterface):
         :param v: node v
         :return: True if a directed edge exists, False otherwise
         """
-        if u.name not in self.nodes:
+        if u.id not in self.nodes:
             return False
-        if v.name not in self.nodes:
+        if v.id not in self.nodes:
             return False
         if u not in self.edges:
             return False
@@ -238,16 +237,19 @@ class UndirectedGraph(BaseGraphInterface):
     def edge_value(self, u: Node, v: Node):
         return self.edges[u][v]
 
-    def add_node(self, name: str, values: List[float]):
+    def add_node(self, name: str, values: List[float], id: str = None):
         """
         Add a node to the graph
         :param name: name of the node
         :param values: values of the node
+        :param id: id of the node
         :param : node
 
         :return:
         """
-        self.nodes[name] = Node(name, values)
+        if id is None:
+            id = str(uuid4())
+        self.nodes[id] = Node(name=name, id=id, values=values)
 
     def directed_path_exists(self, u: Node, v: Node):
         """

--- a/causy/independence_tests.py
+++ b/causy/independence_tests.py
@@ -29,6 +29,7 @@ from causy.interfaces import (
 
 # TODO: make tests configurable (choosing different generators for different algorithms)
 
+
 class CalculateCorrelations(IndependenceTestInterface):
     GENERATOR = AllCombinationsGenerator(
         comparison_settings=ComparisonSettings(min=2, max=2)
@@ -228,7 +229,7 @@ class ExtendedPartialCorrelationTestMatrix(IndependenceTestInterface):
 
         other_neighbours.remove(graph.nodes[nodes[1]])
 
-        if not set(nodes[2:]).issubset(set([on.name for on in list(other_neighbours)])):
+        if not set(nodes[2:]).issubset(set([on.id for on in list(other_neighbours)])):
             return
 
         covariance_matrix = [

--- a/causy/interfaces.py
+++ b/causy/interfaces.py
@@ -36,7 +36,7 @@ class NodeInterface:
     values: List[float]
 
     def to_dict(self):
-        return self.id
+        return {"id": self.id, "name": self.name}
 
 
 class TestResultAction(enum.StrEnum):

--- a/causy/interfaces.py
+++ b/causy/interfaces.py
@@ -32,10 +32,11 @@ class ComparisonSettings:
 
 class NodeInterface:
     name: str
+    id: str
     values: List[float]
 
     def to_dict(self):
-        return self.name
+        return self.id
 
 
 class TestResultAction(enum.StrEnum):

--- a/causy/utils.py
+++ b/causy/utils.py
@@ -134,7 +134,7 @@ def load_pipeline_steps_by_definition(steps):
     return pipeline
 
 
-def show_edges(graph):
+def retrieve_edges(graph):
     edges = []
     for u in graph.edges:
         for v in graph.edges[u]:

--- a/tests/test_pc_graph.py
+++ b/tests/test_pc_graph.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 from causy.algorithms import PC
-from causy.utils import show_edges
+from causy.utils import retrieve_edges
 
 
 # TODO: generate larger toy model to test quadruple orientation rules.
@@ -64,7 +64,7 @@ class PCTestTestCase(unittest.TestCase):
         tst.create_graph_from_data(test_data)
         tst.create_all_possible_edges()
         tst.execute_pipeline_steps()
-        show_edges(tst.graph)
+        retrieve_edges(tst.graph)
 
     def test_with_minimal_toy_model(self):
         a, b, c, d, sample_size = 1.2, 1.7, 2, 1.5, 10000
@@ -73,7 +73,7 @@ class PCTestTestCase(unittest.TestCase):
         tst.create_graph_from_data(test_data)
         tst.create_all_possible_edges()
         tst.execute_pipeline_steps()
-        show_edges(tst.graph)
+        retrieve_edges(tst.graph)
 
     def test_with_larger_toy_model(self):
         a, b, c, d, e, f, g, sample_size = 1.2, 1.7, 2, 1.5, 3, 4, 1.8, 10000
@@ -82,7 +82,7 @@ class PCTestTestCase(unittest.TestCase):
         tst.create_graph_from_data(test_data)
         tst.create_all_possible_edges()
         tst.execute_pipeline_steps()
-        show_edges(tst.graph)
+        retrieve_edges(tst.graph)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Until now we internally used the node names as references. But this has a lot of potential pitfalls (e.g. naming two dimensions the same…). Therefore we now internally use uuids instead of dimension names.

Also the format of the output file changes quite a bit. This also us to store additional meta data which will be helpful when displaying results in causy-ui.

**Old format:**
```
[
    {
        "step": "CalculateCorrelations",
        "actions": [
            {
                "x": "A",
                "y": "B",
                "action": "UPDATE_EDGE"
            },
          …
        ]
   }
]
```

**New format:**
```
{
    "name": "PC",
    "created_at": "2023-10-20T21:43:40.493296",
    "algorithm": {
        "type": "default",
        "reference": "PC"
    },
    "steps": [
        {
            "step": "CalculateCorrelations",
            "actions": []
        },
        {
            "step": "ExtendedPartialCorrelationTestMatrix",
            "actions": []
        },
        {
            "step": "ColliderTest",
            "actions": [
                {
                    "x": {
                        "id": "5cf5c39d-22aa-4e52-a05e-0d7f91061939",
                        "name": "D"
                    },
                    "y": {
                        "id": "987d8977-7c6f-45b2-b39e-d47c0b85a219",
                        "name": "A"
                    },
                    "action": "REMOVE_EDGE_DIRECTED"
                }
            ]
        },
        {
            "step": "NonColliderTest",
            "actions": []
        },
        {
            "step": "FurtherOrientTripleTest",
            "actions": []
        },
        {
            "step": "OrientQuadrupleTest",
            "actions": []
        },
        {
            "step": "FurtherOrientQuadrupleTest",
            "actions": []
        }
    ],
    "nodes": {
        "987d8977-7c6f-45b2-b39e-d47c0b85a219": {
            "id": "987d8977-7c6f-45b2-b39e-d47c0b85a219",
            "name": "A"
        },
        "a7d45b15-186d-47a2-9ec9-118395f4e714": {
            "id": "a7d45b15-186d-47a2-9ec9-118395f4e714",
            "name": "C"
        },
    },
    "edges": [
        [
            {
                "id": "987d8977-7c6f-45b2-b39e-d47c0b85a219",
                "name": "A"
            },
            {
                "id": "b6f7484e-ac14-4261-ac80-a441f2a33465",
                "name": "C"
            }
        ]
    ]
}

```
