### PR TITLE
Remove linear regression model as well as sympy dependency

### DIFF
--- a/causy/generators.py
+++ b/causy/generators.py
@@ -66,6 +66,9 @@ class PairsWithNeighboursGenerator(GeneratorInterface):
         if shuffle_combinations is not None:
             self.shuffle_combinations = shuffle_combinations
 
+        if chunked is not None:
+            self.chunked = chunked
+
     def serialize(self):
         result = super().serialize()
         result["params"]["shuffle_combinations"] = self.shuffle_combinations

--- a/causy/utils.py
+++ b/causy/utils.py
@@ -2,10 +2,8 @@ import importlib
 import logging
 
 import torch
-from sympy import transpose, Matrix, Symbol, shape
 from scipy import stats as scipy_stats
 import math
-from statistics import correlation
 
 logger = logging.getLogger(__name__)
 
@@ -16,90 +14,6 @@ def sum_lists(*lists):
     :return: list (sum of lists)
     """
     return list(map(sum, zip(*lists)))
-
-
-def backward_substituion(R, b, n):
-    """
-    :param R: sympy matrix, nxn-dimensional upper triangular matrix (from QR decomposition)
-    :param b: sympy matrix, n-dimensional vector (b=Q^Tx)
-    :param n: int, dimension
-    :return: Matrix, n-dimensional regression coefficient vector
-    """
-    # TODO: rewrite this function with torch or remove it
-    # Define the symbolic variables
-    my_symbols = []
-    for z in range(n + 1):
-        locals()[f"x{z}"] = Symbol(f"x{z}")
-        my_symbols.append(locals()[f"x{z}"])
-
-    # Initialize the solution vector x
-    x = Matrix([*my_symbols])
-
-    # Solve for x using back-substitution
-    for i in range(n, -1, -1):
-        if i == n:
-            x[i] = b[i] / R[i, i]
-        else:
-            x_temp = 0
-            for o, _ in enumerate(R[i, i + 1 :]):
-                x_temp += x[i + 1 :][o] * R[i, i + 1 :][o]
-            x[i] = (b[i] - x_temp) / R[i, i]
-    return x
-
-
-def get_regression_coefficients(x, Z):
-    """
-    :param x: list (length = # of samples), variable
-    :param Z: list of lists (length of outer list = # of samples, length of inner list = # of variables in Z)
-    :return: sympy matrix, regression coefficients from regressing x on Z
-    """
-    # TODO: rewrite this function with torch or remove it
-    z_matrix = Matrix(Z)
-    (n, m) = shape(z_matrix)
-    logger.debug(f"(n,m)={(n, m)}")
-    if m > n:
-        raise ValueError(
-            "Z must have at most as many rows as columns. (Otherwise you have more variables than samples - which seems to be the case here)"
-        )
-    Q, R = z_matrix.QRdecomposition()
-    if shape(R) != (m, m):
-        raise Exception("The matrix of data we regress on (Z) must have full rank.")
-    q_transposed = transpose(Q)
-    logger.debug(f"Q_transposed shape = {shape(q_transposed)}")
-    logger.debug(f"R shape = {shape(R)}")
-    x_matrix = Matrix(x)
-    logger.debug(f"x shape = {shape(x_matrix)}")
-    b = q_transposed @ x_matrix
-    b_transposed = transpose(b)
-    logger.debug(f"shape b={shape(b)}")
-    regression_coefficients = backward_substituion(R, b_transposed, m - 1)
-    return regression_coefficients
-
-
-def get_residuals(x, Z):
-    """
-    :param x: list (length = # of samples), variable
-    :param y: list (length = # of samples), variable
-    :param Z: list of lists (length of outer list = # of samples, length of inner list = # of variables in Z)
-    :return: residual – list (length = # of samples)
-
-    CAUTION: Z must have full rank
-    TODO: add optional check
-    """
-    # TODO: rewrite this function with torch or remove it
-
-    n = len(x)
-    res_x = Matrix(n, 1, x) - Matrix(Z) @ get_regression_coefficients(x, Z)
-    return list(res_x)
-
-
-def get_correlation(x, y, other_nodes):
-    # TODO: rewrite this function with torch or remove it
-    other_nodes_transposed = [list(i) for i in zip(*other_nodes)]
-    residuals_x = get_residuals(x.values, other_nodes_transposed)
-    residuals_y = get_residuals(y.values, other_nodes_transposed)
-    corr = correlation(residuals_x, residuals_y)
-    return corr
 
 
 def get_t_and_critical_t(sample_size, nb_of_control_vars, par_corr, threshold):

--- a/causy/utils.py
+++ b/causy/utils.py
@@ -64,6 +64,6 @@ def retrieve_edges(graph):
 
 def pearson_correlation(x, y):
     cov_xy = torch.mean((x - x.mean()) * (y - y.mean()))
-    std_x = x.std()
-    std_y = y.std()
+    std_x = x.std(unbiased=False)
+    std_y = y.std(unbiased=False)
     return cov_xy / (std_x * std_y)

--- a/poetry.lock
+++ b/poetry.lock
@@ -698,6 +698,24 @@ files = [
 ]
 
 [[package]]
+name = "opt-einsum"
+version = "3.3.0"
+description = "Optimizing numpys einsum function"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "opt_einsum-3.3.0-py3-none-any.whl", hash = "sha256:2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147"},
+    {file = "opt_einsum-3.3.0.tar.gz", hash = "sha256:59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549"},
+]
+
+[package.dependencies]
+numpy = ">=1.7"
+
+[package.extras]
+docs = ["numpydoc", "sphinx (==1.2.3)", "sphinx-rtd-theme", "sphinxcontrib-napoleon"]
+tests = ["pytest", "pytest-cov", "pytest-pep8"]
+
+[[package]]
 name = "packaging"
 version = "23.2"
 description = "Core utilities for Python packages"
@@ -943,6 +961,48 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pyro-api"
+version = "0.1.2"
+description = "Generic API for dispatch to Pyro backends."
+optional = false
+python-versions = "*"
+files = [
+    {file = "pyro-api-0.1.2.tar.gz", hash = "sha256:a1b900d9580aa1c2fab3b123ab7ff33413744da7c5f440bd4aadc4d40d14d920"},
+    {file = "pyro_api-0.1.2-py3-none-any.whl", hash = "sha256:10e0e42e9e4401ce464dab79c870e50dfb4f413d326fa777f3582928ef9caf8f"},
+]
+
+[package.extras]
+dev = ["ipython", "sphinx (>=2.0)", "sphinx-rtd-theme"]
+test = ["flake8", "pytest (>=5.0)"]
+
+[[package]]
+name = "pyro-ppl"
+version = "1.8.6"
+description = "A Python library for probabilistic modeling and inference"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyro-ppl-1.8.6.tar.gz", hash = "sha256:00d2f4dda8a53e66d955124dc6e49e92dcf570cd3bd706825091db764d93cd07"},
+    {file = "pyro_ppl-1.8.6-py3-none-any.whl", hash = "sha256:18a28febe1be9c42af94a684c2971a798f2acb51f77b07e8430f146eafe11fed"},
+]
+
+[package.dependencies]
+numpy = ">=1.7"
+opt-einsum = ">=2.3.2"
+pyro-api = ">=0.1.1"
+torch = ">=1.11.0"
+tqdm = ">=4.36"
+
+[package.extras]
+dev = ["black (>=21.4b0)", "graphviz (>=0.8)", "jupyter (>=1.0.0)", "lap", "matplotlib (>=1.3)", "mypy (>=0.812)", "nbformat", "nbsphinx (>=0.3.2)", "nbstripout", "nbval", "ninja", "pandas", "pillow (==8.2.0)", "pypandoc", "pytest (>=5.0)", "pytest-xdist", "ruff", "scikit-learn", "scipy (>=1.1)", "seaborn (>=0.11.0)", "sphinx", "sphinx-rtd-theme", "torchvision (>=0.12.0)", "visdom (>=0.1.4,<0.2.2)", "wget", "yapf"]
+extras = ["graphviz (>=0.8)", "jupyter (>=1.0.0)", "lap", "matplotlib (>=1.3)", "pandas", "pillow (==8.2.0)", "scikit-learn", "seaborn (>=0.11.0)", "torchvision (>=0.12.0)", "visdom (>=0.1.4,<0.2.2)", "wget"]
+funsor = ["funsor[torch] (==0.4.4)"]
+horovod = ["horovod[pytorch] (>=0.19)"]
+lightning = ["pytorch-lightning"]
+profile = ["prettytable", "pytest-benchmark", "snakeviz"]
+test = ["black (>=21.4b0)", "graphviz (>=0.8)", "jupyter (>=1.0.0)", "lap", "matplotlib (>=1.3)", "nbval", "pandas", "pillow (==8.2.0)", "pytest (>=5.0)", "pytest-cov", "pytest-xdist", "ruff", "scikit-learn", "scipy (>=1.1)", "seaborn (>=0.11.0)", "torchvision (>=0.12.0)", "visdom (>=0.1.4,<0.2.2)", "wget"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1160,6 +1220,26 @@ typing-extensions = "*"
 opt-einsum = ["opt-einsum (>=3.3)"]
 
 [[package]]
+name = "tqdm"
+version = "4.66.1"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tqdm-4.66.1-py3-none-any.whl", hash = "sha256:d302b3c5b53d47bce91fea46679d9c3c6508cf6332229aa1e7d8653723793386"},
+    {file = "tqdm-4.66.1.tar.gz", hash = "sha256:d88e651f9db8d8551a62556d3cff9e3034274ca5d66e93197cf2490e2dcb69c7"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout", "pytest-xdist"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "typer"
 version = "0.9.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -1214,4 +1294,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "9ec0c3308e6653be5913c3b44110c2686778521474c55cea8524aa2cf4b16ef7"
+content-hash = "7a4f71d837f0b768cbe01624801fd13fa4e03ca1b08107fe81761959e5aca547"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,13 @@
 [tool.poetry]
 name = "causy"
 version = "0.1.0"
-description = ""
+description = "Causal Dicovery made easy."
 authors = ["Sofia Faltenbacher <faltenbacher.sofia@gmail.com>", "Lilith Wittmann <mail@lilithwittmann.de>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.12" # until torch is available for 3.12
-sympy = "^1.12"
 scipy = "^1.11.2"
-pre-commit = "^3.4.0"
 typer = "^0.9.0"
 networkx = "^3.1"
 matplotlib = "^3.8.0"
@@ -22,6 +20,8 @@ pyinstrument = "^4.5.3"
 black = "^23.9.1"
 numpy = "^1.26.0"
 pdoc = "^14.1.0"
+pre-commit = "^3.4.0"
+
 
 [tool.poetry-version-plugin]
 source = "git-tag"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,24 +1,8 @@
 import unittest
 
-from sympy import Matrix
-
-from causy.utils import backward_substituion
-
 
 class UtilsTestCase(unittest.TestCase):
-    def test_QR_decomposition(self):
-        Z = [[1, -1, 4], [1, 4, -2], [1, 4, 2], [1, -1, 0]]
-        M = Matrix(Z)
-        Q, R = M.QRdecomposition()
-        self.assertAlmostEqual(R, Matrix([[2, 3, 2], [0, 5, -2], [0, 0, 4]]))
-
-    def test_backward_substitution(self):
-        R = Matrix([[1, 2, 3], [0, 4, 5], [0, 0, 6]])
-        b = Matrix([6, 15, 24])
-        n = 2
-        self.assertEqual(
-            backward_substituion(R, b, n), Matrix([[-7 / 2], [-5 / 4], [4]])
-        )
+    pass
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,47 @@
 import unittest
+from statistics import correlation
+
+from causy.independence_tests import CalculateCorrelations
+from causy.utils import (
+    pearson_correlation,
+    serialize_module_name,
+    load_pipeline_artefact_by_definition,
+    load_pipeline_steps_by_definition,
+)
+import torch
 
 
 class UtilsTestCase(unittest.TestCase):
-    pass
+    def test_pearson_correlation(self):
+        self.assertEqual(
+            pearson_correlation(
+                torch.tensor([1, 2, 3], dtype=torch.float64),
+                torch.tensor([1, 2, 3], dtype=torch.float64),
+            ).item(),
+            1,
+        )
+        self.assertEqual(
+            pearson_correlation(
+                torch.tensor([1, 2, 3], dtype=torch.float64),
+                torch.tensor([3, 2, 1], dtype=torch.float64),
+            ).item(),
+            -1,
+        )
+
+    def test_serialize_module_name(self):
+        self.assertEqual(serialize_module_name(self), "tests.test_utils.UtilsTestCase")
+
+    def test_load_pipeline_artefact_by_definition(self):
+        step = {"name": "causy.independence_tests.CalculateCorrelations"}
+        self.assertIsInstance(
+            load_pipeline_artefact_by_definition(step), CalculateCorrelations
+        )
+
+    def load_pipeline_steps_by_definition(self):
+        steps = [{"name": "causy.independence_tests.CalculateCorrelations"}]
+        self.assertIsInstance(
+            load_pipeline_steps_by_definition(steps)[0], CalculateCorrelations
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We currently don't use the LinearRegression test. And as it is not super performant - as well as implemented with sympy - we maybe could just remove it for now.