### PR TITLE
fix(causy-share): allow field aliases to be used for parsing too (so output from causy works as input for causy-share)

### DIFF
--- a/causy/ui.py
+++ b/causy/ui.py
@@ -24,8 +24,8 @@ class CausyAlgorithm(BaseModel):
 
 
 class CausyNodePosition(BaseModel):
-    x: float
-    y: float
+    x: Optional[float]
+    y: Optional[float]
 
 
 class CausyNode(BaseModel):
@@ -40,6 +40,10 @@ class CausyEdgeValue(BaseModel):
 
 
 class CausyEdge(BaseModel):
+    class Config:
+        allow_population_by_field_name = True
+        fields = {"from_field": "from"}
+
     from_field: CausyNode = Field(alias="from")
     to: CausyNode
     value: CausyEdgeValue


### PR DESCRIPTION

- see also https://docs.pydantic.dev/1.10/usage/model_config/ https://stackoverflow.com/questions/66936511/pydantic-field-json-alias-simply-does-not-work