### PR TITLE
refactor: rename pipeline steps

### DIFF
--- a/causy/causal_effect_estimation/multivariate_regression.py
+++ b/causy/causal_effect_estimation/multivariate_regression.py
@@ -18,7 +18,7 @@ class ComputeDirectEffectsMultivariateRegression(PipelineStepInterface):
     chunk_size_parallel_processing: int = 1
     parallel: bool = False
 
-    def test(self, nodes: Tuple[str], graph: BaseGraphInterface) -> TestResult:
+    def process(self, nodes: Tuple[str], graph: BaseGraphInterface) -> TestResult:
         """
         Calculate the direct effect of each edge in the graph using multivariate regression.
         :param nodes: list of nodes

--- a/causy/common_pipeline_steps/calculation.py
+++ b/causy/common_pipeline_steps/calculation.py
@@ -24,7 +24,7 @@ class CalculatePearsonCorrelations(
     chunk_size_parallel_processing: int = 1
     parallel: bool = False
 
-    def test(self, nodes: Tuple[str], graph: BaseGraphInterface) -> TestResult:
+    def process(self, nodes: Tuple[str], graph: BaseGraphInterface) -> TestResult:
         """
         Calculate the correlation between each pair of nodes and store it to the respective edge.
         :param nodes: list of nodes

--- a/causy/common_pipeline_steps/placeholder.py
+++ b/causy/common_pipeline_steps/placeholder.py
@@ -18,7 +18,7 @@ class PlaceholderTest(
     chunk_size_parallel_processing: int = 10
     parallel: bool = False
 
-    def test(
+    def process(
         self, nodes: Tuple[str], graph: BaseGraphInterface
     ) -> List[TestResult] | TestResult:
         """

--- a/causy/independence_tests/common.py
+++ b/causy/independence_tests/common.py
@@ -30,7 +30,9 @@ class CorrelationCoefficientTest(
     chunk_size_parallel_processing: int = 1
     parallel: bool = False
 
-    def test(self, nodes: List[str], graph: BaseGraphInterface) -> Optional[TestResult]:
+    def process(
+        self, nodes: List[str], graph: BaseGraphInterface
+    ) -> Optional[TestResult]:
         """
         Test if u and v are independent and delete edge in graph if they are.
         :param nodes: list of nodes
@@ -65,7 +67,7 @@ class PartialCorrelationTest(
     chunk_size_parallel_processing: int = 1
     parallel: bool = False
 
-    def test(
+    def process(
         self, nodes: Tuple[str], graph: BaseGraphInterface
     ) -> Optional[List[TestResult]]:
         """
@@ -142,7 +144,9 @@ class ExtendedPartialCorrelationTestMatrix(
     chunk_size_parallel_processing: int = 1000
     parallel: bool = False
 
-    def test(self, nodes: List[str], graph: BaseGraphInterface) -> Optional[TestResult]:
+    def process(
+        self, nodes: List[str], graph: BaseGraphInterface
+    ) -> Optional[TestResult]:
         """
         Test if nodes u,v are independent given Z (set of nodes) based on partial correlation using the inverted covariance matrix (precision matrix).
         https://en.wikipedia.org/wiki/Partial_correlation#Using_matrix_inversion
@@ -244,7 +248,9 @@ class ExtendedPartialCorrelationTestLinearRegression(
     chunk_size_parallel_processing: int = 1000
     parallel: bool = False
 
-    def test(self, nodes: List[str], graph: BaseGraphInterface) -> Optional[TestResult]:
+    def process(
+        self, nodes: List[str], graph: BaseGraphInterface
+    ) -> Optional[TestResult]:
         if not graph.edge_exists(graph.nodes[nodes[0]], graph.nodes[nodes[1]]):
             return
 

--- a/causy/interfaces.py
+++ b/causy/interfaces.py
@@ -262,7 +262,9 @@ class PipelineStepInterface(ABC, BaseModel, Generic[PipelineStepInterfaceType]):
         return serialize_module_name(self)
 
     @abstractmethod
-    def test(self, nodes: List[str], graph: BaseGraphInterface) -> Optional[TestResult]:
+    def process(
+        self, nodes: List[str], graph: BaseGraphInterface
+    ) -> Optional[TestResult]:
         """
         Test if u and v are independent
         :param u: u values
@@ -274,7 +276,7 @@ class PipelineStepInterface(ABC, BaseModel, Generic[PipelineStepInterfaceType]):
     def __call__(
         self, nodes: List[str], graph: BaseGraphInterface
     ) -> Optional[TestResult]:
-        return self.test(nodes, graph)
+        return self.process(nodes, graph)
 
 
 class ExitConditionInterface(ABC, BaseModel):

--- a/causy/orientation_rules/fci.py
+++ b/causy/orientation_rules/fci.py
@@ -21,7 +21,7 @@ class ColliderRuleFCI(
     chunk_size_parallel_processing: int = 1
     parallel: bool = False
 
-    def test(
+    def process(
         self, nodes: Tuple[str], graph: BaseGraphInterface
     ) -> Optional[List[TestResult] | TestResult]:
         """

--- a/causy/orientation_rules/pc.py
+++ b/causy/orientation_rules/pc.py
@@ -27,7 +27,7 @@ class ColliderTest(
     chunk_size_parallel_processing: int = 1
     parallel: bool = False
 
-    def test(
+    def process(
         self, nodes: Tuple[str], graph: BaseGraphInterface
     ) -> Optional[List[TestResult] | TestResult]:
         """
@@ -95,7 +95,7 @@ class NonColliderTest(
     chunk_size_parallel_processing: int = 1
     parallel: bool = False
 
-    def test(
+    def process(
         self, nodes: Tuple[str], graph: BaseGraphInterface
     ) -> Optional[List[TestResult] | TestResult]:
         """
@@ -161,7 +161,7 @@ class FurtherOrientTripleTest(
     chunk_size_parallel_processing: int = 1
     parallel: bool = False
 
-    def test(
+    def process(
         self, nodes: Tuple[str], graph: BaseGraphInterface
     ) -> Optional[List[TestResult] | TestResult]:
         """
@@ -219,7 +219,7 @@ class OrientQuadrupleTest(
     chunk_size_parallel_processing: int = 1
     parallel: bool = False
 
-    def test(
+    def process(
         self, nodes: Tuple[str], graph: BaseGraphInterface
     ) -> Optional[List[TestResult] | TestResult]:
         """
@@ -287,7 +287,7 @@ class FurtherOrientQuadrupleTest(
     chunk_size_parallel_processing: int = 1
     parallel: bool = False
 
-    def test(
+    def process(
         self, nodes: Tuple[str], graph: BaseGraphInterface
     ) -> Optional[List[TestResult] | TestResult]:
         """


### PR DESCRIPTION
Currently, test is a method on a pipeline step object. It is the logic of our pipeline steps which is used for (independence) tests, (orientation) rules and estimators. As test does not fit all these functions in which the method is used, we renamed the test method to process. The usage of the method stays the same.