### PR TITLE
feat(graph_model): add graph update pre+post hooks

### DIFF
--- a/causy/interfaces.py
+++ b/causy/interfaces.py
@@ -427,3 +427,22 @@ class ExtensionInterface(BaseModel, Generic[ExtensionType]):
     @property
     def name(self) -> str:
         return serialize_module_name(self)
+
+
+class GraphUpdateHook(BaseModel):
+
+    """
+    A hook that is executed before or after the graph is updated. This can be used to modify the graph before or after an update.
+    """
+
+    @abstractmethod
+    def execute(
+        self, graph: BaseGraphInterface, updates: List[TestResultInterface]
+    ) -> Optional[List[TestResultInterface]]:
+        """
+        Execute the hook.
+        :param graph: current state of the graph.
+        :param updates: the planned/taken actions
+        :return: A list of updates that should be applied to the graph if it is a pre hook. If it is a post hook, it should return None.
+        """
+        pass

--- a/causy/models.py
+++ b/causy/models.py
@@ -1,6 +1,4 @@
 import enum
-import hashlib
-import json
 from datetime import datetime
 from typing import Optional, Dict, List, Union, Any
 
@@ -19,6 +17,7 @@ from causy.interfaces import (
     ComparisonSettingsInterface,
     ExtensionInterface,
     EdgeTypeInterfaceType,
+    GraphUpdateHook,
 )
 from causy.variables import IntegerParameter, VariableInterfaceType
 
@@ -78,6 +77,8 @@ class Algorithm(BaseModel):
     edge_types: List[EdgeTypeInterfaceType]
     extensions: Optional[List[ExtensionType]] = None
     variables: Optional[List[Union[VariableInterfaceType]]] = None
+    pre_graph_update_hooks: Optional[List[GraphUpdateHook]] = None
+    post_graph_update_hooks: Optional[List[GraphUpdateHook]] = None
 
     def hash(self) -> str:
         return hash_dictionary(self.model_dump())

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,85 @@
+from typing import List, Optional
+
+from causy.causal_discovery.constraint.algorithms.pc import PC_EDGE_TYPES
+from causy.causal_discovery.constraint.independence_tests.common import (
+    CorrelationCoefficientTest,
+)
+from causy.common_pipeline_steps.calculation import CalculatePearsonCorrelations
+from causy.interfaces import GraphUpdateHook, BaseGraphInterface, TestResultInterface
+from causy.sample_generator import IIDSampleGenerator, SampleEdge, NodeReference
+from causy.models import Algorithm
+from causy.graph_model import graph_model_factory
+
+from tests.utils import CausyTestCase
+
+
+class RemoveAllActionsHook(GraphUpdateHook):
+    def execute(
+        self, graph: BaseGraphInterface, updates: List[TestResultInterface]
+    ) -> Optional[List[TestResultInterface]]:
+        return []
+
+
+class HookTestException(Exception):
+    pass
+
+
+class ThrowExceptionHook(GraphUpdateHook):
+    def execute(
+        self, graph: BaseGraphInterface, updates: List[TestResultInterface]
+    ) -> Optional[List[TestResultInterface]]:
+        raise HookTestException("This is a test exception")
+
+
+class HooksTestCase(CausyTestCase):
+    def test_pre_graph_update_hook(self):
+        samples = IIDSampleGenerator(
+            edges=[
+                SampleEdge(NodeReference("X"), NodeReference("Y"), 5),
+                SampleEdge(NodeReference("Y"), NodeReference("Z"), 7),
+            ]
+        )
+
+        data, graph = samples.generate(100)
+        algorithm = Algorithm(
+            pipeline_steps=[
+                CalculatePearsonCorrelations(),
+                CorrelationCoefficientTest(threshold=0.05),
+            ],
+            name="pc",
+            edge_types=PC_EDGE_TYPES,
+            extensions=[],
+            pre_graph_update_hooks=[RemoveAllActionsHook()],
+        )
+
+        model = graph_model_factory(algorithm)()
+        model.create_graph_from_data(data)
+        model.create_all_possible_edges()
+        model.execute_pipeline_steps()
+        self.assertEqual(len(model.graph.action_history[0].actions), 0)
+
+    def test_post_graph_update_hook(self):
+        samples = IIDSampleGenerator(
+            edges=[
+                SampleEdge(NodeReference("X"), NodeReference("Y"), 5),
+                SampleEdge(NodeReference("Y"), NodeReference("Z"), 7),
+            ]
+        )
+
+        data, graph = samples.generate(100)
+        algorithm = Algorithm(
+            pipeline_steps=[
+                CalculatePearsonCorrelations(),
+                CorrelationCoefficientTest(threshold=0.05),
+            ],
+            name="pc",
+            edge_types=PC_EDGE_TYPES,
+            extensions=[],
+            post_graph_update_hooks=[ThrowExceptionHook()],
+        )
+
+        model = graph_model_factory(algorithm)()
+        model.create_graph_from_data(data)
+        model.create_all_possible_edges()
+        with self.assertRaises(HookTestException):
+            model.execute_pipeline_steps()

--- a/tests/test_orientation_tests.py
+++ b/tests/test_orientation_tests.py
@@ -282,9 +282,7 @@ class OrientationRuleTestCase(CausyTestCase):
         self.assertTrue(model.graph.undirected_edge_exists(y, z))
 
     def test_collider_multiple_colliders(self):
-        pipeline = [
-            ColliderTest()
-        ]
+        pipeline = [ColliderTest()]
         model = graph_model_factory(
             Algorithm(
                 pipeline_steps=pipeline,


### PR DESCRIPTION
Hooks are code snippets that are custom code snippets which can be executed before or after an update of the graph happens. They can be e.g. used to filter certain updates (applying prior knowledge) or logging error states.

Currently there is a pre and a post hook for graph updates. Both receive the planned/executed updates. But while the pre hook can manipulate them the post hook can only receive them.