### PR TITLE
refactor causal effect estimation pipeline step

### DIFF
--- a/causy/causal_discovery/constraint/algorithms/pc.py
+++ b/causy/causal_discovery/constraint/algorithms/pc.py
@@ -1,5 +1,5 @@
 from causy.causal_effect_estimation.multivariate_regression import (
-    ComputeDirectEffectsMultivariateRegression,
+    ComputeDirectEffectsInDAGsMultivariateRegression,
 )
 from causy.common_pipeline_steps.exit_conditions import ExitOnNoActions
 from causy.contrib.graph_ui import GraphUIExtension
@@ -77,9 +77,6 @@ PC = graph_model_factory(
                 display_name="Extended Partial Correlation Test Matrix",
             ),
             *PC_ORIENTATION_RULES,
-            ComputeDirectEffectsMultivariateRegression(
-                display_name="Compute Direct Effects"
-            ),
         ],
         edge_types=PC_EDGE_TYPES,
         extensions=[PC_GRAPH_UI_EXTENSION],
@@ -106,7 +103,6 @@ PCStable = graph_model_factory(
                 ]
             ),
             *PC_ORIENTATION_RULES,
-            ComputeDirectEffectsMultivariateRegression(),
         ],
         edge_types=PC_EDGE_TYPES,
         extensions=[PC_GRAPH_UI_EXTENSION],
@@ -162,9 +158,6 @@ ParallelPC = graph_model_factory(
                 ),
             ),
             *PC_ORIENTATION_RULES,
-            ComputeDirectEffectsMultivariateRegression(
-                display_name="Compute Direct Effects"
-            ),
         ],
         edge_types=PC_EDGE_TYPES,
         extensions=[PC_GRAPH_UI_EXTENSION],

--- a/causy/causal_effect_estimation/multivariate_regression.py
+++ b/causy/causal_effect_estimation/multivariate_regression.py
@@ -11,7 +11,7 @@ from causy.interfaces import (
 from causy.models import TestResultAction, TestResult
 
 
-class ComputeDirectEffectsMultivariateRegression(PipelineStepInterface):
+class ComputeDirectEffectsInDAGsMultivariateRegression(PipelineStepInterface):
     generator: Optional[GeneratorInterface] = PairsWithEdgesInBetweenGenerator()
 
     chunk_size_parallel_processing: int = 1
@@ -38,23 +38,6 @@ class ComputeDirectEffectsMultivariateRegression(PipelineStepInterface):
                 action=TestResultAction.UPDATE_EDGE_DIRECTED,
                 data=edge_data,
             )
-
-        # if there is an undirected edge adjacent to the cause variable on a path to the effect variable, the effect is not identifiable
-        for path in graph.all_paths_on_underlying_undirected_graph(
-            cause_variable, effect_variable
-        ):
-            if not graph.only_directed_edge_exists(path[0], path[1]):
-                edge_data = graph.edge_value(cause_variable, effect_variable)
-                if "direct_effect" in edge_data:
-                    return
-                edge_data["direct_effect"] = None
-
-                return TestResult(
-                    u=graph.nodes[nodes[0]],
-                    v=graph.nodes[nodes[1]],
-                    action=TestResultAction.UPDATE_EDGE_DIRECTED,
-                    data=edge_data,
-                )
 
         edge_data = graph.edge_value(cause_variable, effect_variable)
 

--- a/causy/graph.py
+++ b/causy/graph.py
@@ -215,6 +215,21 @@ class GraphBaseAccessMixin:
             return True
         return False
 
+    def get_siblings(self, v: Union[Node, str]) -> Set[Union[Node, str]]:
+        """
+        Get the set of nodes that are connected to the node v with an undirected edge.
+        :param v: node v
+        :return: A set of nodes that are connected to v with an undirected edge.
+        """
+        siblings = set()
+
+        # Assuming self.nodes is a list or set of all nodes in the graph
+        for node in self.nodes:
+            if node != v and self.undirected_edge_exists(v, node):
+                siblings.add(node)
+
+        return siblings
+
     def retrieve_edge_history(
         self, u: Union[Node, str], v: Union[Node, str], action: TestResultAction = None
     ) -> List[TestResult]:

--- a/tests/test_effect_estimation.py
+++ b/tests/test_effect_estimation.py
@@ -232,12 +232,12 @@ class EffectEstimationTestCase(CausyTestCase):
             tst.graph.edge_value(tst.graph.nodes["W"], tst.graph.nodes["X"])[
                 "direct_effect"
             ],
-            None
+            None,
         )
 
         self.assertEqual(
             tst.graph.edge_value(tst.graph.nodes["W"], tst.graph.nodes["Y"])[
                 "direct_effect"
             ],
-            None
+            None,
         )

--- a/tests/test_effect_estimation.py
+++ b/tests/test_effect_estimation.py
@@ -11,7 +11,7 @@ from causy.causal_discovery.constraint.independence_tests.common import (
 )
 from causy.causal_discovery.constraint.orientation_rules.pc import ColliderTest
 from causy.causal_effect_estimation.multivariate_regression import (
-    ComputeDirectEffectsMultivariateRegression,
+    ComputeDirectEffectsInDAGsMultivariateRegression,
 )
 from causy.common_pipeline_steps.calculation import CalculatePearsonCorrelations
 from causy.graph_model import graph_model_factory
@@ -44,7 +44,7 @@ class EffectEstimationTestCase(CausyTestCase):
                         display_name="Extended Partial Correlation Test Matrix",
                     ),
                     *PC_ORIENTATION_RULES,
-                    ComputeDirectEffectsMultivariateRegression(
+                    ComputeDirectEffectsInDAGsMultivariateRegression(
                         display_name="Compute Direct Effects"
                     ),
                 ],
@@ -104,7 +104,7 @@ class EffectEstimationTestCase(CausyTestCase):
                         display_name="Extended Partial Correlation Test Matrix",
                     ),
                     *PC_ORIENTATION_RULES,
-                    ComputeDirectEffectsMultivariateRegression(
+                    ComputeDirectEffectsInDAGsMultivariateRegression(
                         display_name="Compute Direct Effects"
                     ),
                 ],
@@ -162,4 +162,82 @@ class EffectEstimationTestCase(CausyTestCase):
             ],
             4.0,
             0,
+        )
+
+    def test_direct_effect_estimation_partially_directed(self):
+        PC = graph_model_factory(
+            Algorithm(
+                pipeline_steps=[
+                    CalculatePearsonCorrelations(
+                        display_name="Calculate Pearson Correlations"
+                    ),
+                    CorrelationCoefficientTest(
+                        threshold=VariableReference(name="threshold"),
+                        display_name="Correlation Coefficient Test",
+                    ),
+                    PartialCorrelationTest(
+                        threshold=VariableReference(name="threshold"),
+                        display_name="Partial Correlation Test",
+                    ),
+                    ExtendedPartialCorrelationTestMatrix(
+                        threshold=VariableReference(name="threshold"),
+                        display_name="Extended Partial Correlation Test Matrix",
+                    ),
+                    *PC_ORIENTATION_RULES,
+                    ComputeDirectEffectsInDAGsMultivariateRegression(
+                        display_name="Compute Direct Effects"
+                    ),
+                ],
+                edge_types=PC_EDGE_TYPES,
+                extensions=[PC_GRAPH_UI_EXTENSION],
+                name="PC",
+                variables=[FloatVariable(name="threshold", value=PC_DEFAULT_THRESHOLD)],
+            )
+        )
+
+        model = IIDSampleGenerator(
+            edges=[
+                SampleEdge(NodeReference("X"), NodeReference("Z"), 5),
+                SampleEdge(NodeReference("Y"), NodeReference("Z"), 6),
+                SampleEdge(NodeReference("W"), NodeReference("X"), 3),
+                SampleEdge(NodeReference("W"), NodeReference("Y"), 4),
+            ],
+        )
+
+        tst = PC()
+        sample_size = 1000000
+        test_data, graph = model.generate(sample_size)
+        tst.create_graph_from_data(test_data)
+        tst.create_all_possible_edges()
+        tst.execute_pipeline_steps()
+
+        self.assertGraphStructureIsEqual(tst.graph, graph)
+
+        self.assertAlmostEqual(
+            tst.graph.edge_value(tst.graph.nodes["X"], tst.graph.nodes["Z"])[
+                "direct_effect"
+            ],
+            5.0,
+            0,
+        )
+        self.assertAlmostEqual(
+            tst.graph.edge_value(tst.graph.nodes["Y"], tst.graph.nodes["Z"])[
+                "direct_effect"
+            ],
+            6.0,
+            0,
+        )
+
+        self.assertEqual(
+            tst.graph.edge_value(tst.graph.nodes["W"], tst.graph.nodes["X"])[
+                "direct_effect"
+            ],
+            None
+        )
+
+        self.assertEqual(
+            tst.graph.edge_value(tst.graph.nodes["W"], tst.graph.nodes["Y"])[
+                "direct_effect"
+            ],
+            None
         )

--- a/tests/test_pc_graph.py
+++ b/tests/test_pc_graph.py
@@ -1,8 +1,26 @@
 import csv
 
 from causy.causal_discovery.constraint.algorithms import PC
+from causy.causal_discovery.constraint.algorithms.pc import (
+    PC_ORIENTATION_RULES,
+    PC_EDGE_TYPES,
+    PC_GRAPH_UI_EXTENSION,
+    PC_DEFAULT_THRESHOLD,
+)
+from causy.causal_discovery.constraint.independence_tests.common import (
+    CorrelationCoefficientTest,
+    PartialCorrelationTest,
+    ExtendedPartialCorrelationTestMatrix,
+)
+from causy.causal_effect_estimation.multivariate_regression import (
+    ComputeDirectEffectsInDAGsMultivariateRegression,
+)
+from causy.common_pipeline_steps.calculation import CalculatePearsonCorrelations
+from causy.graph_model import graph_model_factory
 from causy.graph_utils import retrieve_edges
+from causy.models import Algorithm
 from causy.sample_generator import IIDSampleGenerator, SampleEdge, NodeReference
+from causy.variables import VariableReference, FloatVariable
 
 from tests.utils import CausyTestCase
 
@@ -44,9 +62,36 @@ class PCTestTestCase(CausyTestCase):
             random=lambda: rdnv(0, 1),
         )
         sample_size = 100000
+        tst = graph_model_factory(
+            Algorithm(
+                pipeline_steps=[
+                    CalculatePearsonCorrelations(
+                        display_name="Calculate Pearson Correlations"
+                    ),
+                    CorrelationCoefficientTest(
+                        threshold=VariableReference(name="threshold"),
+                        display_name="Correlation Coefficient Test",
+                    ),
+                    PartialCorrelationTest(
+                        threshold=VariableReference(name="threshold"),
+                        display_name="Partial Correlation Test",
+                    ),
+                    ExtendedPartialCorrelationTestMatrix(
+                        threshold=VariableReference(name="threshold"),
+                        display_name="Extended Partial Correlation Test Matrix",
+                    ),
+                    *PC_ORIENTATION_RULES,
+                    ComputeDirectEffectsInDAGsMultivariateRegression(
+                        display_name="Compute Direct Effects"
+                    ),
+                ],
+                edge_types=PC_EDGE_TYPES,
+                extensions=[PC_GRAPH_UI_EXTENSION],
+                name="PC",
+                variables=[FloatVariable(name="threshold", value=PC_DEFAULT_THRESHOLD)],
+            )
+        )()
         test_data, graph = model.generate(sample_size)
-
-        tst = PC()
         tst.create_graph_from_data(test_data)
         tst.create_all_possible_edges()
         tst.execute_pipeline_steps()


### PR DESCRIPTION
also: add siblings function in preparation for CPDAG effect estimation, one more test, remove effect estimation for DAGs from PC default pipeline